### PR TITLE
Fix realtime audio resampling without external FFmpeg

### DIFF
--- a/packages/discord-bot/src/voice/AudioPlaybackHandler.ts
+++ b/packages/discord-bot/src/voice/AudioPlaybackHandler.ts
@@ -1,18 +1,12 @@
 import { AudioPlayer, VoiceConnection, AudioPlayerStatus, AudioPlayerError, createAudioResource, StreamType } from '@discordjs/voice';
 import { logger } from '../utils/logger.js';
 import { GuildAudioPipeline } from './GuildAudioPipeline.js';
-import { PassThrough } from 'stream';
-import { once } from 'events';
-import { createPlaybackResampler } from './audioTransforms.js';
+import { upsampleToDiscord } from './audioTransforms.js';
 
 export class AudioPlaybackHandler {
     private pipelines: Map<string, GuildAudioPipeline> = new Map();
     private audioQueues: Map<string, Buffer[]> = new Map();
     private isProcessingQueue: Map<string, boolean> = new Map();
-    private playbackInputs: Map<string, PassThrough> = new Map();
-    private playbackResamplers: Map<string, ReturnType<typeof createPlaybackResampler>> = new Map();
-    private resamplerQueues: Map<string, Buffer[]> = new Map();
-    private resamplerProcessing: Map<string, boolean> = new Map();
 
     public async playAudioToChannel(connection: VoiceConnection, audioData: Buffer): Promise<void> {
         const guildId = connection.joinConfig.guildId;
@@ -52,34 +46,6 @@ export class AudioPlaybackHandler {
         logger.debug(`[AudioPlayback] Creating new audio pipeline for guild ${guildId}`);
         const pipeline = new GuildAudioPipeline();
         this.pipelines.set(guildId, pipeline);
-
-        const resamplerInput = new PassThrough();
-        const resampler = createPlaybackResampler();
-        const resampledQueue: Buffer[] = [];
-
-        resamplerInput.setMaxListeners(20);
-        resampler.setMaxListeners(20);
-
-        this.playbackInputs.set(guildId, resamplerInput);
-        this.playbackResamplers.set(guildId, resampler);
-        this.resamplerQueues.set(guildId, resampledQueue);
-        this.resamplerProcessing.set(guildId, false);
-
-        resampler.on('data', (chunk: Buffer) => {
-            const queue = this.resamplerQueues.get(guildId);
-            if (!queue) {
-                return;
-            }
-
-            queue.push(chunk);
-            void this.processResampledQueue(guildId, pipeline);
-        });
-
-        resampler.on('error', (error: Error) => {
-            logger.error(`[AudioPlayback] Playback resampler error for guild ${guildId}:`, error);
-        });
-
-        resamplerInput.pipe(resampler);
 
         // Set up player event handlers
         const player = pipeline.getPlayer();
@@ -148,12 +114,17 @@ export class AudioPlaybackHandler {
                 if (!audioData) continue;
 
                 try {
-                    await this.writeToResampler(guildId, audioData);
+                    const pcmChunk = upsampleToDiscord(audioData);
+                    if (pcmChunk.length === 0) {
+                        continue;
+                    }
+
+                    await pipeline.writePCM(pcmChunk);
                 } catch (error) {
                     logger.error('[AudioPlayback] Error writing audio data to pipeline:', error);
                 }
             }
-    
+
             this.isProcessingQueue.set(guildId, false);
         } catch (error) {
             logger.error('[AudioPlayback] Error in processAudioQueue:', error);
@@ -191,73 +162,6 @@ export class AudioPlaybackHandler {
             this.pipelines.delete(guildId);
         }
 
-        const resamplerInput = this.playbackInputs.get(guildId);
-        if (resamplerInput) {
-            try {
-                resamplerInput.removeAllListeners();
-                resamplerInput.end();
-            } catch (error) {
-                logger.error(`[AudioPlayback] Error ending resampler input for guild ${guildId}:`, error);
-            }
-            this.playbackInputs.delete(guildId);
-        }
-
-        const resampler = this.playbackResamplers.get(guildId);
-        if (resampler) {
-            try {
-                resampler.removeAllListeners();
-                resampler.destroy();
-            } catch (error) {
-                logger.error(`[AudioPlayback] Error destroying resampler for guild ${guildId}:`, error);
-            }
-            this.playbackResamplers.delete(guildId);
-        }
-
-        this.resamplerQueues.delete(guildId);
-        this.resamplerProcessing.delete(guildId);
-    }
-
-    private async writeToResampler(guildId: string, audioData: Buffer): Promise<void> {
-        const resamplerInput = this.playbackInputs.get(guildId);
-        if (!resamplerInput) {
-            throw new Error(`No playback resampler input for guild ${guildId}`);
-        }
-
-        if (!resamplerInput.write(audioData)) {
-            await once(resamplerInput, 'drain');
-        }
-    }
-
-    private async processResampledQueue(guildId: string, pipeline: GuildAudioPipeline): Promise<void> {
-        if (this.resamplerProcessing.get(guildId)) {
-            return;
-        }
-
-        const queue = this.resamplerQueues.get(guildId);
-        if (!queue) {
-            return;
-        }
-
-        this.resamplerProcessing.set(guildId, true);
-
-        try {
-            while (queue.length > 0) {
-                const chunk = queue.shift();
-                if (!chunk) {
-                    continue;
-                }
-
-                await pipeline.writePCM(chunk);
-            }
-        } catch (error) {
-            logger.error(`[AudioPlayback] Error writing resampled audio for guild ${guildId}:`, error);
-        } finally {
-            this.resamplerProcessing.set(guildId, false);
-
-            if (queue.length > 0) {
-                void this.processResampledQueue(guildId, pipeline);
-            }
-        }
     }
 
     public cleanupGuild(guildId: string): void {

--- a/packages/discord-bot/src/voice/audioTransforms.ts
+++ b/packages/discord-bot/src/voice/audioTransforms.ts
@@ -1,35 +1,44 @@
-import prism from 'prism-media';
 import { AUDIO_CONSTANTS } from '../constants/voice.js';
 
-type PCMResamplerOptions = {
-    fromRate: number;
-    toRate: number;
-    channels?: number;
+const BYTES_PER_SAMPLE = 2; // 16-bit PCM
+
+/**
+ * Resamples 16-bit mono PCM audio between sample rates using linear interpolation.
+ * The implementation avoids the need for an external FFmpeg binary which proved
+ * unreliable in some deployment environments and resulted in empty capture buffers.
+ */
+export const resamplePCM = (buffer: Buffer, fromRate: number, toRate: number): Buffer => {
+    if (buffer.length === 0 || fromRate === toRate) {
+        return Buffer.from(buffer);
+    }
+
+    const inputSampleCount = Math.floor(buffer.length / BYTES_PER_SAMPLE);
+    if (inputSampleCount === 0) {
+        return Buffer.alloc(0);
+    }
+
+    const resampleRatio = toRate / fromRate;
+    const outputSampleCount = Math.max(1, Math.floor(inputSampleCount * resampleRatio));
+    const outputBuffer = Buffer.allocUnsafe(outputSampleCount * BYTES_PER_SAMPLE);
+
+    for (let i = 0; i < outputSampleCount; i++) {
+        const sourceIndex = i / resampleRatio;
+        const lowerIndex = Math.floor(sourceIndex);
+        const upperIndex = Math.min(lowerIndex + 1, inputSampleCount - 1);
+        const interpolation = sourceIndex - lowerIndex;
+
+        const lowerSample = buffer.readInt16LE(lowerIndex * BYTES_PER_SAMPLE);
+        const upperSample = buffer.readInt16LE(upperIndex * BYTES_PER_SAMPLE);
+
+        const sampleValue = lowerSample + (upperSample - lowerSample) * interpolation;
+        outputBuffer.writeInt16LE(Math.round(sampleValue), i * BYTES_PER_SAMPLE);
+    }
+
+    return outputBuffer;
 };
 
-const createPCMResampler = ({ fromRate, toRate, channels = AUDIO_CONSTANTS.CHANNELS }: PCMResamplerOptions): prism.FFmpeg => {
-    return new prism.FFmpeg({
-        args: [
-            '-loglevel', 'error',
-            '-f', 's16le',
-            '-ar', fromRate.toString(),
-            '-ac', channels.toString(),
-            '-i', 'pipe:0',
-            '-f', 's16le',
-            '-ar', toRate.toString(),
-            '-ac', channels.toString(),
-        ],
-    });
-};
+export const downsampleToRealtime = (buffer: Buffer): Buffer =>
+    resamplePCM(buffer, AUDIO_CONSTANTS.DISCORD_SAMPLE_RATE, AUDIO_CONSTANTS.REALTIME_SAMPLE_RATE);
 
-export const createCaptureResampler = (): prism.FFmpeg =>
-    createPCMResampler({
-        fromRate: AUDIO_CONSTANTS.DISCORD_SAMPLE_RATE,
-        toRate: AUDIO_CONSTANTS.REALTIME_SAMPLE_RATE,
-    });
-
-export const createPlaybackResampler = (): prism.FFmpeg =>
-    createPCMResampler({
-        fromRate: AUDIO_CONSTANTS.REALTIME_SAMPLE_RATE,
-        toRate: AUDIO_CONSTANTS.DISCORD_SAMPLE_RATE,
-    });
+export const upsampleToDiscord = (buffer: Buffer): Buffer =>
+    resamplePCM(buffer, AUDIO_CONSTANTS.REALTIME_SAMPLE_RATE, AUDIO_CONSTANTS.DISCORD_SAMPLE_RATE);


### PR DESCRIPTION
## Summary
- replace the FFmpeg-based capture and playback resamplers with a pure TypeScript linear interpolator
- update audio capture to resample PCM chunks directly so speech is buffered instead of being dropped as noise
- simplify playback to upsample realtime output buffers before writing to the Discord pipeline, avoiding encoder shutdowns

## Testing
- npm run build -w @ai-assistant/discord-bot

------
https://chatgpt.com/codex/tasks/task_e_68e00e101470832f8630cd00a6172de3