### PR TITLE
Add realtime voice session rate limiting

### DIFF
--- a/packages/discord-bot/src/events/VoiceStateHandler.ts
+++ b/packages/discord-bot/src/events/VoiceStateHandler.ts
@@ -247,7 +247,7 @@ export class VoiceStateHandler extends Event {
         try {
             logger.info(`Started conversation in guild ${guildId}`);
             await this.activateRealtimeLimit(guildId, session);
-            await session.realtimeSession.sendGreeting();
+            await session.realtimeSession.sendGreeting("Hello! I'm Daneel, your AI assistant. How can I help you?");
             session.isActive = true;
         } catch (error) {
             if (session?.initiatingUserId) {

--- a/packages/discord-bot/src/realtime/RealtimeEventHandler.ts
+++ b/packages/discord-bot/src/realtime/RealtimeEventHandler.ts
@@ -69,10 +69,12 @@ export class RealtimeEventHandler extends EventEmitter {
             this.audioBuffer = [];
         });
 
-        // Handle response completion
-        this.on('response.completed', (event: RealtimeResponseCompletedEvent) => {
+        // Handle response completion events from different schema versions
+        const onResponseCompleted = (event: RealtimeResponseCompletedEvent) => {
             this.emit('responseComplete', event);
-        });
+        };
+
+        this.on('response.completed', onResponseCompleted);
 
         // Handle errors
         this.on('error', (event: RealtimeErrorEvent) => {
@@ -106,6 +108,9 @@ export class RealtimeEventHandler extends EventEmitter {
         } else {
             // Emit both the specific event type and a generic 'event' for other events
             this.emit(event.type, event);
+            if (event.type === 'response.done') {
+                this.emit('response.completed', event as any);
+            }
             this.emit('event', event);
         }
 

--- a/packages/discord-bot/src/utils/RealtimeUsageLimiter.ts
+++ b/packages/discord-bot/src/utils/RealtimeUsageLimiter.ts
@@ -1,0 +1,142 @@
+interface UsageRecord {
+    start: number;
+    durationMs: number;
+}
+
+interface ActiveSession {
+    start: number;
+    allowedMs: number;
+}
+
+export interface RealtimeUsageLimiterOptions {
+    limitMinutes: number;
+    windowHours: number;
+    superUserIds?: string[];
+}
+
+export interface RealtimeAllowance {
+    allowed: boolean;
+    remainingMs: number;
+    limitMs: number;
+    windowMs: number;
+    retryAfterMs?: number;
+    isSuperuser: boolean;
+}
+
+export class RealtimeUsageLimiter {
+    private readonly limitMs: number;
+    private readonly windowMs: number;
+    private readonly superUserIds: Set<string>;
+    private readonly usageRecords: Map<string, UsageRecord[]> = new Map();
+    private readonly activeSessions: Map<string, ActiveSession> = new Map();
+
+    constructor(options: RealtimeUsageLimiterOptions) {
+        this.limitMs = Math.max(0, options.limitMinutes * 60_000);
+        this.windowMs = Math.max(0, options.windowHours * 3_600_000);
+        this.superUserIds = new Set(options.superUserIds ?? []);
+    }
+
+    private isSuperuser(userId: string | undefined): boolean {
+        if (!userId) return false;
+        return this.superUserIds.has(userId);
+    }
+
+    private pruneOldRecords(userId: string, now: number): void {
+        const records = this.usageRecords.get(userId);
+        if (!records || records.length === 0) return;
+
+        while (records.length > 0 && now - records[0].start >= this.windowMs) {
+            records.shift();
+        }
+
+        if (records.length === 0) {
+            this.usageRecords.delete(userId);
+        }
+    }
+
+    private getRecords(userId: string): UsageRecord[] {
+        let records = this.usageRecords.get(userId);
+        if (!records) {
+            records = [];
+            this.usageRecords.set(userId, records);
+        }
+        return records;
+    }
+
+    public getAllowance(userId: string): RealtimeAllowance {
+        const now = Date.now();
+        if (this.isSuperuser(userId)) {
+            return {
+                allowed: true,
+                remainingMs: Number.POSITIVE_INFINITY,
+                limitMs: Number.POSITIVE_INFINITY,
+                windowMs: this.windowMs,
+                isSuperuser: true,
+            };
+        }
+
+        this.pruneOldRecords(userId, now);
+        const records = this.usageRecords.get(userId) ?? [];
+        const usedMs = records.reduce((total, record) => total + record.durationMs, 0);
+        const remainingMs = Math.max(0, this.limitMs - usedMs);
+        const allowed = remainingMs > 0;
+
+        const allowance: RealtimeAllowance = {
+            allowed,
+            remainingMs,
+            limitMs: this.limitMs,
+            windowMs: this.windowMs,
+            isSuperuser: false,
+        };
+
+        if (!allowed && records.length > 0) {
+            const retryAfterMs = Math.max(0, records[0].start + this.windowMs - now);
+            allowance.retryAfterMs = retryAfterMs;
+        }
+
+        return allowance;
+    }
+
+    public startSession(userId: string): ActiveSession {
+        const allowance = this.getAllowance(userId);
+        if (!allowance.allowed && !allowance.isSuperuser) {
+            throw new Error('Realtime usage limit reached for this user.');
+        }
+
+        const now = Date.now();
+        const allowedMs = allowance.isSuperuser
+            ? Number.POSITIVE_INFINITY
+            : Math.max(0, Math.min(allowance.remainingMs, this.limitMs));
+
+        const active: ActiveSession = { start: now, allowedMs };
+        this.activeSessions.set(userId, active);
+        return active;
+    }
+
+    public endSession(userId: string, endTime: number = Date.now()): number {
+        const active = this.activeSessions.get(userId);
+        if (!active) {
+            return 0;
+        }
+
+        this.activeSessions.delete(userId);
+
+        if (this.isSuperuser(userId)) {
+            return 0;
+        }
+
+        const duration = Math.max(0, Math.min(endTime - active.start, active.allowedMs));
+        if (duration === 0) {
+            return 0;
+        }
+
+        this.pruneOldRecords(userId, endTime);
+        const records = this.getRecords(userId);
+        records.push({ start: active.start, durationMs: duration });
+        return duration;
+    }
+
+    public cancelSession(userId: string): void {
+        this.activeSessions.delete(userId);
+    }
+}

--- a/packages/discord-bot/src/utils/prompting/RealtimeContextBuilder.ts
+++ b/packages/discord-bot/src/utils/prompting/RealtimeContextBuilder.ts
@@ -25,7 +25,7 @@ SYSTEM CONTEXT
 - Activated in a voice channel via the /call command. At least one caller is present, possibly more.
 
 PERSONA
-- You are R. Daneel Olivaw ("Daneel" or "Danny"), inspired by Isaac Asimov's Robot and Foundation novels.
+- You are R. Daneel Olivaw ("Daneel" pronounced "duh-kneel"), inspired by Isaac Asimov's Robot and Foundation novels.
 - Speak as one participant in conversation, not as a generic AI assistant.
 - Tone: urbane charm, persuasive cadence, subtle wit, gentle irony.
 - Style: concise but memorable; warmth and logic balanced with polish.

--- a/packages/discord-bot/src/utils/realtimeService.ts
+++ b/packages/discord-bot/src/utils/realtimeService.ts
@@ -182,4 +182,22 @@ export class RealtimeSession extends EventEmitter {
             }
         }));
     }
+
+    public async sendFarewell(message: string): Promise<void> {
+        const ws = this.wsManager.getWebSocket();
+        if (!ws) return;
+
+        ws.send(JSON.stringify({
+            type: 'conversation.item.create',
+            item: { type: 'message', role: 'user', content: [{ type: 'input_text', text: message }] }
+        }));
+
+        ws.send(JSON.stringify({
+            type: 'response.create',
+            response: {
+                output_modalities: ['audio'],
+                instructions: (`${this.sessionConfig.getInstructions() ?? ''}` + ` Say: ${message}`).trim()
+            }
+        }));
+    }
 }

--- a/packages/discord-bot/src/utils/realtimeService.ts
+++ b/packages/discord-bot/src/utils/realtimeService.ts
@@ -163,7 +163,7 @@ export class RealtimeSession extends EventEmitter {
         throw new Error('Event handler not initialized');
     }
 
-    public async sendGreeting(): Promise<void> {
+    public async sendGreeting(message: string): Promise<void> {
         const ws = this.wsManager.getWebSocket();
         if (!ws) return;
 
@@ -178,7 +178,7 @@ export class RealtimeSession extends EventEmitter {
             type: 'response.create',
             response: {
                 output_modalities: ['audio'],
-                instructions: (`${this.sessionConfig.getInstructions() ?? ''}` + " Say: Hello!").trim()
+                instructions: (`BEGIN INSTRUCTIONS: ${this.sessionConfig.getInstructions() ?? ''} END OF INSTRUCTIONS. Say exactly this: ${message}`).trim()
             }
         }));
     }
@@ -196,7 +196,7 @@ export class RealtimeSession extends EventEmitter {
             type: 'response.create',
             response: {
                 output_modalities: ['audio'],
-                instructions: (`${this.sessionConfig.getInstructions() ?? ''}` + ` Say: ${message}`).trim()
+                instructions: (`BEGIN INSTRUCTIONS: ${this.sessionConfig.getInstructions() ?? ''} END OF INSTRUCTIONS. Say exactly this: ${message}`).trim()
             }
         }));
     }

--- a/packages/discord-bot/src/voice/VoiceSessionManager.ts
+++ b/packages/discord-bot/src/voice/VoiceSessionManager.ts
@@ -14,6 +14,9 @@ export interface VoiceSession {
     initiatingUserId?: string;
     participantLabels: Map<string, string>;
     audioPipeline: Promise<void>;
+    usageLimitTimer?: NodeJS.Timeout;
+    usageLimitStartedAt?: number;
+    usageLimitAllowedMs?: number;
 }
 
 export class VoiceSessionManager {
@@ -37,6 +40,9 @@ export class VoiceSessionManager {
             initiatingUserId,
             participantLabels: new Map(participants),
             audioPipeline: Promise.resolve(),
+            usageLimitTimer: undefined,
+            usageLimitStartedAt: undefined,
+            usageLimitAllowedMs: undefined,
         };
     }
 
@@ -149,6 +155,10 @@ export class VoiceSessionManager {
         const session = this.activeSessions.get(guildId);
         if (session) {
             try {
+                if (session.usageLimitTimer) {
+                    clearTimeout(session.usageLimitTimer);
+                    session.usageLimitTimer = undefined;
+                }
                 this.cleanupSessionEventListeners(session);
                 session.realtimeSession.disconnect();
             } catch (error) {


### PR DESCRIPTION
## Summary
- add a reusable realtime usage limiter to track per-user allowance windows
- enforce conversation limits in the voice session flow, including timed shutdown and farewell playback
- surface remaining allowance in the /call command and extend the realtime session helper to send farewells

## Testing
- npm run build -w @ai-assistant/discord-bot

------
https://chatgpt.com/codex/tasks/task_e_68e059fb2d44832f874dbe41af204bab