### PR TITLE
Make Discord TTS cleanup asynchronous

### DIFF
--- a/packages/discord-bot/src/utils/MessageProcessor.ts
+++ b/packages/discord-bot/src/utils/MessageProcessor.ts
@@ -226,8 +226,7 @@ export class MessageProcessor {
                 }],
                 true // Make it a reply
               );
-              // delete the tts file
-              fs.unlinkSync(ttsPath);
+              await cleanupTTSFile(ttsPath);
             } else {
               // Not tts, send regular response
               await responseHandler.sendMessage(responseText, [], directReply);
@@ -266,5 +265,20 @@ export class MessageProcessor {
     if (this.rateLimiters.guild && message.guild) results.push(await this.rateLimiters.guild.check(message.author.id, message.channel.id, message.guild.id));
 
     return results.find(r => !r.allowed) ?? { allowed: true };
+  }
+}
+
+export async function cleanupTTSFile(ttsPath: string): Promise<void> {
+  if (!ttsPath) return;
+
+  try {
+    await fs.promises.unlink(ttsPath);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') {
+      return;
+    }
+
+    logger.debug(`Failed to delete TTS file ${ttsPath}: ${err?.message ?? err}`);
   }
 }

--- a/packages/discord-bot/test/ttsCleanup.test.ts
+++ b/packages/discord-bot/test/ttsCleanup.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { cleanupTTSFile } from '../src/utils/MessageProcessor.js';
+
+const { promises: fsp } = fs;
+
+test('cleanupTTSFile removes generated speech files without throwing on missing files', async () => {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'tts-cleanup-'));
+  const speechPath = path.join(tmpDir, 'sample.mp3');
+
+  try {
+    await fsp.writeFile(speechPath, 'test');
+
+    await cleanupTTSFile(speechPath);
+
+    await assert.rejects(fsp.access(speechPath), (error: NodeJS.ErrnoException) => {
+      assert.equal(error.code, 'ENOENT');
+      return true;
+    });
+
+    await cleanupTTSFile(speechPath);
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## Summary
- replace synchronous text-to-speech cleanup with an async helper that tolerates missing files and logs unexpected failures at debug level
- add a node:test that exercises the helper to confirm generated files are removed without surfacing ENOENT errors

## Testing
- npx tsx --test packages/discord-bot/test/ttsCleanup.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e245641744832f95d1d03c6a3261d0