### PR TITLE
Add style preset support to Discord image command

### DIFF
--- a/packages/discord-bot/src/commands/image/cloudinary.ts
+++ b/packages/discord-bot/src/commands/image/cloudinary.ts
@@ -69,6 +69,7 @@ export async function uploadToCloudinary(imageBuffer: Buffer, metadata: UploadMe
             quality: metadata.quality,
             size: metadata.size,
             background: metadata.background,
+            style_preset: metadata.style,
             generated_at: nowIso,
             generation_time: `${(Date.now() - metadata.startTime) / 1000}s`,
             text_input_tokens: metadata.usage.inputTokens.toString(),
@@ -102,7 +103,7 @@ export async function uploadToCloudinary(imageBuffer: Buffer, metadata: UploadMe
             resource_type: 'image',
             public_id: `ai-image-${Date.now()}`,
             context,
-            tags: ['ai-generated', 'discord-bot', metadata.model, metadata.quality]
+            tags: ['ai-generated', 'discord-bot', metadata.model, metadata.quality, metadata.style]
         });
 
         logger.debug(`Image uploaded to Cloudinary: ${uploadResult.secure_url}`);

--- a/packages/discord-bot/src/commands/image/openai.ts
+++ b/packages/discord-bot/src/commands/image/openai.ts
@@ -20,6 +20,7 @@ import type {
     ImageQualityType,
     ImageResponseModel,
     ImageSizeType,
+    ImageStylePreset,
     PartialImagePayload,
     ReflectionFields
 } from './types.js';
@@ -32,6 +33,7 @@ interface GenerateImageOptions {
     quality: ImageQualityType;
     size: ImageSizeType;
     background: ImageBackgroundType;
+    style: ImageStylePreset;
     allowPromptAdjustment: boolean;
     followUpResponseId?: string | null;
     onPartialImage?: (payload: PartialImagePayload) => Promise<void> | void;
@@ -46,7 +48,18 @@ interface GenerationOutcome {
 }
 
 export async function generateImageWithReflection(options: GenerateImageOptions): Promise<GenerationOutcome> {
-    const { openai, prompt, model, quality, size, background, allowPromptAdjustment, followUpResponseId, onPartialImage } = options;
+    const {
+        openai,
+        prompt,
+        model,
+        quality,
+        size,
+        background,
+        style,
+        allowPromptAdjustment,
+        followUpResponseId,
+        onPartialImage
+    } = options;
 
     const input: ResponseInput = [
         {
@@ -61,7 +74,8 @@ export async function generateImageWithReflection(options: GenerateImageOptions)
                 allowPromptAdjustment,
                 size,
                 quality,
-                background
+                background,
+                style
             }) }]
         },
         {
@@ -71,13 +85,14 @@ export async function generateImageWithReflection(options: GenerateImageOptions)
         }
     ];
 
-    const imageTool: Tool.ImageGeneration = {
+    const imageTool = {
         type: 'image_generation',
         size,
         quality,
         background,
+        style_preset: style,
         partial_images: PARTIAL_IMAGE_LIMIT
-    };
+    } satisfies Tool.ImageGeneration & { style_preset: ImageStylePreset };
 
     const toolChoice: ToolChoiceTypes = { type: 'image_generation' };
 

--- a/packages/discord-bot/src/commands/image/prompts.ts
+++ b/packages/discord-bot/src/commands/image/prompts.ts
@@ -1,4 +1,9 @@
-import type { ImageBackgroundType, ImageQualityType, ImageSizeType } from './types.js';
+import type {
+    ImageBackgroundType,
+    ImageQualityType,
+    ImageSizeType,
+    ImageStylePreset
+} from './types.js';
 
 export const IMAGE_SYSTEM_PROMPT = `You are the Discord bot extension of an AI assistant monorepo. You were built in TypeScript with discord.js and OpenAI's API.
 You play the character of R. Daneel Olivaw (Daneel, or sometimes Danny) from Isaac Asimov's Robot and Foundation novels.
@@ -9,6 +14,7 @@ interface DeveloperPromptOptions {
     size: ImageSizeType;
     quality: ImageQualityType;
     background: ImageBackgroundType;
+    style: ImageStylePreset;
 }
 
 export function buildDeveloperPrompt(options: DeveloperPromptOptions): string {
@@ -19,7 +25,7 @@ export function buildDeveloperPrompt(options: DeveloperPromptOptions): string {
     return [
         'You are orchestrating a Discord `/image` command for Daneel.',
         'Call the `image_generation` tool exactly once to create a single image.',
-        `Target size: ${options.size}. Quality: ${options.quality}. Background: ${options.background}.`,
+        `Target size: ${options.size}. Quality: ${options.quality}. Background: ${options.background}. Style preset: ${options.style}.`,
         adjustmentClause,
         'After the tool call, reply with a single-line JSON object with the keys `title`, `description`, `reflection`, and `adjusted_prompt`.',
         'The JSON must not use code fences. Use standard double-quoted JSON. No commentary.',

--- a/packages/discord-bot/src/commands/image/types.ts
+++ b/packages/discord-bot/src/commands/image/types.ts
@@ -5,9 +5,11 @@ export type ImageResponseModel = 'gpt-4o' | 'gpt-4o-mini' | 'gpt-4.1' | 'gpt-4.1
 export type ImageQualityType = ImageGenerationQuality;
 export type ImageSizeType = ImageGenerationSize;
 export type ImageBackgroundType = 'auto' | 'transparent' | 'opaque';
+export type ImageStylePreset = 'natural' | 'vivid' | 'anime' | 'line_art';
 
 export type ImageGenerationCallWithPrompt = ResponseOutputItem.ImageGenerationCall & {
     revised_prompt?: string | null;
+    style_preset?: ImageStylePreset | null;
 };
 
 export interface ReflectionFields {
@@ -49,6 +51,7 @@ export interface UploadMetadata {
     quality: ImageQualityType;
     size: ImageSizeType;
     background: ImageBackgroundType;
+    style: ImageStylePreset;
     startTime: number;
     usage: CloudinaryUsageMetadata;
     cost: CloudinaryCostMetadata;


### PR DESCRIPTION
## Summary
- add a `/image` style option with curated presets and surface the selection in embeds
- thread the style preset through OpenAI payloads, developer prompts, and reflection metadata
- store the style alongside Cloudinary metadata and tagging for easier discovery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e34034dd2c832fae76b1a7cc3a9623