### PR TITLE
Adjust daneel-site flow and add interim invite guides

### DIFF
--- a/packages/daneel-site/public/LICENSE
+++ b/packages/daneel-site/public/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jordan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/daneel-site/public/deployment-guide/index.html
+++ b/packages/daneel-site/public/deployment-guide/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Daneel Deployment Preview</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      body {
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+        background: #fdfcf9;
+        color: #2b2a27;
+        margin: 0;
+        padding: 3.5rem 1.5rem 5rem;
+        display: flex;
+        justify-content: center;
+      }
+
+      main {
+        width: min(100%, 840px);
+      }
+
+      h1 {
+        font-size: clamp(1.65rem, 3.5vw, 2.4rem);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        margin-bottom: 1.5rem;
+      }
+
+      h2 {
+        font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+        letter-spacing: 0.04em;
+      }
+
+      p,
+      li {
+        line-height: 1.7;
+      }
+
+      .callout {
+        background: rgba(193, 160, 87, 0.12);
+        border-left: 4px solid #c1a057;
+        padding: 1.2rem 1.4rem;
+        font-family: "SFMono-Regular", "JetBrains Mono", "Courier New", monospace;
+        margin-bottom: 2rem;
+      }
+
+      .grid {
+        display: grid;
+        gap: 1.75rem;
+        margin: 2.5rem 0;
+      }
+
+      .grid article {
+        border: 1px solid #e3ddd2;
+        background: rgba(247, 242, 233, 0.6);
+        padding: 1.35rem 1.5rem;
+      }
+
+      .back-link {
+        display: inline-flex;
+        margin-top: 3rem;
+        text-decoration: none;
+        font-family: "SFMono-Regular", "JetBrains Mono", "Courier New", monospace;
+        border: 1px solid #e3ddd2;
+        padding: 0.75rem 1.2rem;
+        color: inherit;
+        background: #f7f2e9;
+      }
+
+      .back-link:hover,
+      .back-link:focus {
+        border-color: #4a7c59;
+        background: #e9ecdf;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Deployment guide &amp; technical overview</h1>
+      <div class="callout">
+        Full documentation is on the way. This preview gives you enough structure to bring a test deployment online
+        until the canonical guide is published.
+      </div>
+      <section class="grid">
+        <article>
+          <h2>1. Prerequisites</h2>
+          <ul>
+            <li>Docker Desktop or a compatible container runtime.</li>
+            <li>Node.js 20+ if you prefer to run services directly.</li>
+            <li>A Discord application with bot permissions and the message content intent enabled.</li>
+          </ul>
+        </article>
+        <article>
+          <h2>2. Configure secrets</h2>
+          <p>
+            Duplicate <code>.env.example</code> to <code>.env</code> in the repository root. Supply your OpenAI credentials,
+            Discord bot token, and any other provider keys noted in the sample file.
+          </p>
+        </article>
+        <article>
+          <h2>3. Start the stack</h2>
+          <p>
+            Run <code>docker compose up --build</code> from the repository root. Docker will assemble the backend, web
+            client, and supporting workers.
+          </p>
+          <p>
+            Prefer manual control? Each package has an <code>npm run dev</code> script so you can iterate locally while
+            proxying through Vite.
+          </p>
+        </article>
+        <article>
+          <h2>4. Authorise your bot</h2>
+          <p>
+            Use the Discord OAuth URL generator with scopes <code>bot</code> and <code>applications.commands</code>. Grant the
+            permissions you are comfortable with (the sample configuration recommends <code>Send Messages</code>,
+            <code>Read Message History</code>, and <code>Use Slash Commands</code>).
+          </p>
+        </article>
+        <article>
+          <h2>5. Configure values</h2>
+          <p>
+            Inside Discord, run <code>/configure</code> and walk through the prompts that describe your community norms.
+            Daneel stores these guardrails securely and honours them in every conversation.
+          </p>
+        </article>
+        <article>
+          <h2>6. Stay in touch</h2>
+          <p>
+            The roadmap is evolving. Watch the <a href="https://github.com/daneel-ai/daneel">repository</a> or join the
+            development Discord server to help guide the upcoming release notes.
+          </p>
+        </article>
+      </section>
+      <a class="back-link" href="/">Return to the landing page</a>
+    </main>
+  </body>
+</html>

--- a/packages/daneel-site/public/invite/index.html
+++ b/packages/daneel-site/public/invite/index.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Invite Daneel</title>
+    <style>
+      body {
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+        background: #fdfcf9;
+        color: #2b2a27;
+        margin: 0;
+        padding: 3rem 1.5rem 5rem;
+        display: flex;
+        justify-content: center;
+      }
+
+      main {
+        width: min(100%, 760px);
+      }
+
+      h1 {
+        font-size: clamp(1.85rem, 4vw, 2.6rem);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin-bottom: 1rem;
+      }
+
+      p {
+        line-height: 1.65;
+      }
+
+      .step-list {
+        margin: 2.5rem 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .step-list li {
+        border-left: 3px solid #4a7c59;
+        padding: 0.25rem 0 0.25rem 1rem;
+        background: rgba(74, 124, 89, 0.08);
+      }
+
+      .actions {
+        margin-top: 2.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .actions a {
+        font-family: "SFMono-Regular", "JetBrains Mono", "Courier New", monospace;
+        text-decoration: none;
+        color: #2b2a27;
+        border: 1px solid #e3ddd2;
+        padding: 0.85rem 1.4rem;
+        display: inline-flex;
+        width: fit-content;
+        background: #f7f2e9;
+      }
+
+      .actions a:hover,
+      .actions a:focus {
+        background: #e9ecdf;
+        border-color: #c1a057;
+      }
+
+      footer {
+        margin-top: 3rem;
+        font-family: "SFMono-Regular", "JetBrains Mono", "Courier New", monospace;
+        font-size: 0.9rem;
+        color: #5b574f;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Invite Daneel</h1>
+      <p>
+        The public invite link is being finalised with Discord. Until then, you can still experiment with Daneel by
+        running your own instance and connecting it to a development server.
+      </p>
+      <ol class="step-list">
+        <li><strong>Clone the repository</strong> and follow the environment instructions in the README.</li>
+        <li><strong>Create a Discord application</strong> with bot permissions and copy its client ID.</li>
+        <li><strong>Run the docker compose stack</strong> or the Node services directly to bring Daneel online.</li>
+        <li><strong>Authorise your bot</strong> using the OAuth URL builder with the scopes documented in the README.</li>
+      </ol>
+      <p>
+        Once the production invite is ready, this page will redirect you automatically. For now, it keeps curious
+        visitors from hitting a broken link.
+      </p>
+      <div class="actions">
+        <a href="https://discord.com/developers/applications">Open Discord Developer Portal</a>
+        <a href="https://github.com/daneel-ai/daneel#readme">Read the deployment notes</a>
+        <a href="/">Return to the landing page</a>
+      </div>
+      <footer>Last updated: preview guidance &mdash; July 2024</footer>
+    </main>
+  </body>
+</html>

--- a/packages/daneel-site/src/App.tsx
+++ b/packages/daneel-site/src/App.tsx
@@ -13,11 +13,11 @@ const App = (): JSX.Element => (
     <main>
       <Hero />
       <MeetDaneel />
-      <Invite />
       <Services />
-      <Arete />
       <OpenAccountable />
       <EthicsNote />
+      <Invite />
+      <Arete />
       <Footer />
     </main>
   </div>

--- a/packages/daneel-site/src/components/Hero.tsx
+++ b/packages/daneel-site/src/components/Hero.tsx
@@ -2,8 +2,8 @@ import ThemeToggle from './ThemeToggle';
 
 // Centralised configuration for hero call-to-action links so they are easy to update later.
 const CTA_LINKS = {
-  invite:
-    'https://discord.com/api/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=274877991936&scope=bot%20applications.commands',
+  // The invite link intentionally routes to a temporary explainer while the public OAuth client is finalised.
+  invite: '/invite/',
   philosophy: 'https://github.com/daneel-ai/daneel/blob/main/PHILOSOPHY.md',
   source: 'https://github.com/daneel-ai/daneel',
 };
@@ -13,7 +13,7 @@ const Hero = (): JSX.Element => (
   <section className="hero" aria-labelledby="hero-title">
     <header className="site-header">
       <div className="site-title-group">
-        <p className="site-mark">Daneel</p>
+        <p className="site-mark">DANEEL</p>
         <p className="site-tagline">Ethical companion, open source, self-hosted</p>
       </div>
       <ThemeToggle />

--- a/packages/daneel-site/src/components/Invite.tsx
+++ b/packages/daneel-site/src/components/Invite.tsx
@@ -35,8 +35,8 @@ const Invite = (): JSX.Element => (
         </article>
       ))}
     </div>
-    <a className="inline-cta" href="https://github.com/daneel-ai/daneel/wiki" target="_blank" rel="noreferrer">
-      🛠 Deployment guide &amp; technical overview (soon)
+    <a className="inline-cta" href="/deployment-guide/">
+      🛠 Deployment guide &amp; technical overview (preview)
     </a>
   </section>
 );

--- a/packages/daneel-site/src/styles/global.css
+++ b/packages/daneel-site/src/styles/global.css
@@ -139,11 +139,14 @@ a:focus {
 }
 
 .site-mark {
-  font-size: 1.05rem;
-  letter-spacing: 0.18em;
+  font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+  letter-spacing: 0.24em;
   text-transform: uppercase;
   margin: 0;
   font-family: var(--mono-font);
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text) 85%, var(--accent) 15%);
+  line-height: 1.1;
 }
 
 .site-tagline {

--- a/packages/daneel-site/src/theme.tsx
+++ b/packages/daneel-site/src/theme.tsx
@@ -26,17 +26,15 @@ const STORAGE_KEY = 'daneel-theme-preference';
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-// Determine the initial theme: stored preference wins, otherwise fall back to the OS preference.
+// Determine the initial theme: stored preference wins, otherwise we deliberately start in light mode.
+// Designers asked for the light palette to be the first impression regardless of OS preference so the
+// brand feels consistent on every new visit.
 const resolveInitialTheme = (): Theme => {
   if (supportsLocalStorage()) {
     const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
     if (stored === 'light' || stored === 'dark') {
       return stored;
     }
-  }
-
-  if (typeof window !== 'undefined' && window.matchMedia) {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
   return 'light';


### PR DESCRIPTION
## Summary
- default the landing page to light mode and highlight the DANEEL title without overpowering the header
- reorder the primary sections and update hero/invite CTAs to working interim pages while Discord invite is pending
- add temporary invite and deployment guide pages plus expose the MIT licence within the static assets

## Testing
- npm run build -w @ai-assistant/daneel-site

------
https://chatgpt.com/codex/tasks/task_e_68e5152a9d48832f98762b8c92b6a8f2